### PR TITLE
Show ping for autopunch hosts

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -89,10 +89,17 @@ void Load() {
 	Menu::Load();
 }
 
+bool menuInit = false;
+
 void Render() {
 	CMenuConnect* menu = SokuMan::GetCMenuConnect();
 	if (menu != NULL) {
 		if (firstTime) {
+			if(!menuInit) {
+				menuInit = true;
+				PingMan::Init();
+				atexit(PingMan::Cleanup);
+			}
 			Menu::OnMenuOpen();
 			Hostlist::OnMenuOpen();
 
@@ -185,9 +192,6 @@ void Init(void *unused) {
 	
 	WebMan::Init();
 	atexit(WebMan::Cleanup);
-	
-	PingMan::Init();
-	atexit(PingMan::Cleanup);
 	
 	HostingOptions::Init();
 	Menu::Init();


### PR DESCRIPTION
This simple patch simply delays the PingMan initialisation to when the
network menu appears.

This makes PingMan run its "bind" syscall for the ping socket a few
seconds after the game starts (while the game loads and the user opens
the VS network menu), which makes it run after autopunch has
initialized. This way, when we bind the socket, autopunch can properly
recognize it and inject its magic in ping messages.

Previously, we ran the bind call on game start, before autopunch had
time to check for updates and initialize itself. This meant that the
first bind call wasn't seen by autopunch, and autopunch then ignored the
next calls made on this socket, therefore not injecting hole-punching in
ping messages.

So delaying the PingMan init enables autopunch to properly detect the
socket, and show the ping for autopunch hosts. Tested locally.